### PR TITLE
Make ENTER key expand abbrevs before execution

### DIFF
--- a/src/abbrev-alias
+++ b/src/abbrev-alias
@@ -18,7 +18,16 @@ __abbrev_alias::magic_abbrev_expand() {
     newbuffer=$(eval "echo \"$newbuffer\"")
   fi
   LBUFFER+=$newbuffer
-  zle self-insert
+}
+
+__abbrev_alias::magic_abbrev_expand_and_insert() {
+    zle __abbrev_alias::magic_abbrev_expand
+    zle self-insert
+}
+
+__abbrev_alias::magic_abbrev_expand_and_accept_line() {
+    zle __abbrev_alias::magic_abbrev_expand
+    zle accept-line
 }
 
 __abbrev_alias::no_magic_abbrev_expand() {
@@ -29,8 +38,12 @@ __abbrev_alias::init() {
   setopt extended_glob
   zle -N __abbrev_alias::magic_abbrev_expand
   zle -N __abbrev_alias::no_magic_abbrev_expand
-  bindkey " "   __abbrev_alias::magic_abbrev_expand
-  bindkey "^x " __abbrev_alias::no_magic_abbrev_expand
+  zle -N __abbrev_alias::magic_abbrev_expand_and_insert
+  zle -N __abbrev_alias::magic_abbrev_expand_and_accept_line
+  bindkey " "    __abbrev_alias::magic_abbrev_expand_and_insert
+  bindkey "^M"   __abbrev_alias::magic_abbrev_expand_and_accept_line
+  bindkey "^x "  __abbrev_alias::no_magic_abbrev_expand
+  bindkey "^x^M" accept-line
 }
 
 __abbrev_alias::list() {


### PR DESCRIPTION
It's good for having a meaningful command history, also this is the the behavior of _fish shell_ abbreviations. 

If you don't like this behavior I can make it optional, like `abbrev-alias --init-with-enter-expands`.