### PR TITLE
feat(you-should-use): check for YSU_VERSION

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ $ git push origin B<push space key>
 ->
 $ git push origin master 
 ```
+## Notes
+This plugin is compatible with https://github.com/MichaelAquilina/zsh-you-should-use,
+you only need to source it first
 
 ## Help
 Show `abbrev-alias --help`.

--- a/src/abbrev-alias
+++ b/src/abbrev-alias
@@ -99,6 +99,9 @@ __abbrev_alias::unregist() {
   fi
 }
 
+if [[ -v $YSU_VERSION ]]; then
+  typeset -agUx YSU_IGNORED_ALIASES
+fi
 __abbrev_alias::regist() {
   local kind=$1 is_eval=$2 key=${3%%=*} value=${3#*=}
   if [[ "$kind" == "f" ]]; then
@@ -112,6 +115,10 @@ __abbrev_alias::regist() {
     g) alias -g $key="$value";;
     c) alias    $key="$value";;
   esac
+
+  if [[ -v $YSU_VERSION ]]; then
+    YSU_IGNORED_ALIASES+=($key)
+  fi
   _abbrev_aliases[$key]="$kind\0$is_eval\0$value"
 }
 


### PR DESCRIPTION
Make the plugin compatible with
https://github.com/MichaelAquilina/zsh-you-should-use by default,
because obviously if an alias is already expanded, there is no need to
remember to use an alias.

The fix is pretty quick and the plugin is well maintained and useful, i think is worth it.


----

#