### PR TITLE
Make opts local to not clash with other plugins

### DIFF
--- a/src/abbrev-alias
+++ b/src/abbrev-alias
@@ -123,6 +123,7 @@ __abbrev_alias::regist() {
 }
 
 # option parse & execute
+local -A opts
 zparseopts -D -M -A opts -- \
   -init i=-init \
   -help h=-help \


### PR DESCRIPTION
If another plugin also doesn't make it local, the following error may be shown:

  bad set of key/value pairs for associative array

See https://github.com/ohmyzsh/ohmyzsh/issues/9429