### PR TITLE
improve alias expansion

### DIFF
--- a/src/abbrev-alias
+++ b/src/abbrev-alias
@@ -37,7 +37,7 @@ __abbrev_alias::recursive_command() {
 __abbrev_alias::magic_abbrev_expand() {
   emulate -L zsh -o extended_glob
   local MATCH
-  LBUFFER=${LBUFFER%%(#m)[-_a-zA-Z0-9#%+.~]#}
+  LBUFFER=${LBUFFER%%(#m)[-_a-zA-Z0-9#%+.~,:]#}
   local abbr=${_abbrev_aliases[$MATCH]}
   local kind=${${(s.\0.)abbr}[1]}
   local newbuffer=${${(s.\0.)abbr}[2]:-$MATCH}

--- a/src/abbrev-alias
+++ b/src/abbrev-alias
@@ -37,7 +37,7 @@ __abbrev_alias::recursive_command() {
 __abbrev_alias::magic_abbrev_expand() {
   emulate -L zsh -o extended_glob
   local MATCH
-  LBUFFER=${LBUFFER%%(#m)[-_a-zA-Z0-9#%+.~,:]#}
+  LBUFFER=${LBUFFER%%(#m)[-_a-zA-Z0-9#%+.~,:/]#}
   local abbr=${_abbrev_aliases[$MATCH]}
   local kind=${${(s.\0.)abbr}[1]}
   local newbuffer=${${(s.\0.)abbr}[2]:-$MATCH}


### PR DESCRIPTION
## 1. support `,` and `:` in a name

```sh
$ abbrev-alias -c ,a="echo AAA"

$ # Before
$ ,a<CR> # is not expanded, but displayed "AAA"
AAA

$ # After
$ ,a<CR>
  ↓
$ echo AAA
AAA
```

## 2. improve alias expansion

```sh
$ abbrev-alias -c a="echo AAA"

$ # Before
$ a<SP>    → echo AAA
$ ;␣a<SP>  → ;␣echo AAA
$ ␣a<SP>   → ␣a
$ ;␣␣a<SP> → ;␣␣a

$ # After
$ a<SP>    → echo AAA
$ ;␣a<SP>  → ;␣echo AAA
$ ␣a<SP>   → ␣echo AAA
$ ;␣␣a<SP> → ;␣␣echo AAA
```